### PR TITLE
Add Home Similar widget (CLIP neighbors)

### DIFF
--- a/api/controllers/Home.controller.test.ts
+++ b/api/controllers/Home.controller.test.ts
@@ -7,6 +7,7 @@ const {
   getHomeHealth,
   getHomeHealthLite,
   getHomeExtendedStats,
+  getHomeSimilar,
   searchMediaByName,
   searchTagsByName,
   searchGlobal,
@@ -16,6 +17,7 @@ const {
   getHomeHealth: vi.fn(),
   getHomeHealthLite: vi.fn(),
   getHomeExtendedStats: vi.fn(),
+  getHomeSimilar: vi.fn(),
   searchMediaByName: vi.fn(),
   searchTagsByName: vi.fn(),
   searchGlobal: vi.fn(),
@@ -36,6 +38,10 @@ vi.mock('../services/homeHealth', () => ({
 
 vi.mock('../services/homeExtendedStats', () => ({
   getHomeExtendedStats,
+}))
+
+vi.mock('../services/homeSimilar', () => ({
+  getHomeSimilar,
 }))
 
 vi.mock('../services/globalSearch', () => ({
@@ -105,6 +111,20 @@ describe('Home.controller', () => {
     expect(getRandomMarks).toHaveBeenCalledWith({}, 16)
     expect(res.statusCode).toBe(200)
     expect(res.body).toEqual({marks: [{id: 1}]})
+  })
+
+  it('returns home similar media', async () => {
+    const payload = {seed: {id: 7, name: 'Seed', reason: 'viewed'}, items: [{id: 8}]}
+    getHomeSimilar.mockResolvedValue(payload)
+
+    const req = {query: {limit: '6'}} as unknown as ApiRequest
+    const res = createResponse()
+
+    await controller.getSimilar(req, res)
+
+    expect(getHomeSimilar).toHaveBeenCalledWith({}, {limit: 6})
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual(payload)
   })
 
   it('returns 500 when extended stats fail', async () => {

--- a/api/controllers/Home.controller.ts
+++ b/api/controllers/Home.controller.ts
@@ -6,6 +6,7 @@ import { getRandomMarks } from '../services/homeMarkers'
 import { getHomeHealth, getHomeHealthLite } from '../services/homeHealth'
 import { getHomeExtendedStats } from '../services/homeExtendedStats'
 import { getHomeChartStats } from '../services/homeChartStats'
+import { getHomeSimilar } from '../services/homeSimilar'
 import { searchMediaByName, searchTagsByName, searchGlobal } from '../services/globalSearch'
 import { parseClampedLimit } from '../utils/parseRequestNumber'
 
@@ -70,6 +71,16 @@ export default (db: ApiDb) => {
     }
   }
 
+  const getSimilar = async function (req: ApiRequest, res: ApiResponse) {
+    try {
+      const limit = parseClampedLimit(req.query.limit, 12)
+      const data = await getHomeSimilar(db, {limit})
+      sendOk(res, data)
+    } catch (err) {
+      sendControllerError(res, err, 'Some error occurred while retrieving home similar media.')
+    }
+  }
+
   const searchMedia = async function (req: ApiRequest, res: ApiResponse) {
     try {
       const q = req.body?.q ?? req.body?.query
@@ -114,6 +125,7 @@ export default (db: ApiDb) => {
     getHealthLite,
     getExtendedStats,
     getChartStats,
+    getSimilar,
     searchMedia,
     searchTags,
     searchGlobal: searchGlobalHandler,

--- a/api/routes/Home.routes.ts
+++ b/api/routes/Home.routes.ts
@@ -19,6 +19,7 @@ export default function registerRoutes(app: Express, db: ApiDb) {
 
   router.get('/media', validateQuery(HomeMediaQuerySchema), Home.getMedia)
   router.get('/markers', validateQuery(HomeMarkersQuerySchema), Home.getMarkers)
+  router.get('/similar', validateQuery(HomeMarkersQuerySchema), Home.getSimilar)
   router.get('/health', Home.getHealth)
   router.get('/health-lite', Home.getHealthLite)
   router.get('/extended-stats', Home.getExtendedStats)

--- a/api/services/homeSimilar.test.ts
+++ b/api/services/homeSimilar.test.ts
@@ -1,0 +1,10 @@
+import {describe, expect, it} from 'vitest'
+import {chooseHomeSimilarSeedId} from './homeSimilar'
+
+describe('homeSimilar', () => {
+  it('picks a deterministic seed from candidates', () => {
+    expect(chooseHomeSimilarSeedId([])).toBeNull()
+    expect(chooseHomeSimilarSeedId([10, 20, 30], () => 0)).toBe(10)
+    expect(chooseHomeSimilarSeedId([10, 20, 30], () => 0.99)).toBe(30)
+  })
+})

--- a/api/services/homeSimilar.ts
+++ b/api/services/homeSimilar.ts
@@ -1,0 +1,141 @@
+import type {ApiDb, AnyRecord} from '../types/db'
+import {queryAll, queryGet} from '../db/utils/rawQuery'
+import {
+  CLIP_EMBEDDING_INDEX_KEY,
+  findSimilarByClip,
+} from './mediaClipEmbeddings'
+import {loadMediaBasicsByIds} from './mediaItemsLoader'
+
+export type HomeSimilarSeedReason = 'viewed' | 'favorite' | 'any'
+
+export type HomeSimilarSeed = {
+  id: number
+  name?: string | null
+  basename?: string | null
+  path?: string | null
+  mediaTypeId?: number | null
+  reason: HomeSimilarSeedReason
+}
+
+export type HomeSimilarResult = {
+  seed: HomeSimilarSeed | null
+  items: AnyRecord[]
+}
+
+const SEED_CANDIDATE_LIMIT = 8
+
+function mapSeedRow(row: AnyRecord, reason: HomeSimilarSeedReason): HomeSimilarSeed {
+  return {
+    id: Number(row.id),
+    name: row.name ?? null,
+    basename: row.basename ?? null,
+    path: row.path ?? null,
+    mediaTypeId: row.mediaTypeId == null ? null : Number(row.mediaTypeId),
+    reason,
+  }
+}
+
+/** Prefer recently viewed seeds; fall back to favorites, then any indexed media. */
+export function chooseHomeSimilarSeedId(
+  candidateIds: number[],
+  random: () => number = Math.random,
+): number | null {
+  const ids = candidateIds
+    .map(Number)
+    .filter((id) => Number.isFinite(id) && id > 0)
+  if (!ids.length) return null
+  const index = Math.min(ids.length - 1, Math.floor(random() * ids.length))
+  return ids[index] ?? null
+}
+
+function loadSeedCandidates(db: ApiDb, reason: HomeSimilarSeedReason): HomeSimilarSeed[] {
+  let sql = `
+    SELECT media.id, media.name, media.basename, media.path, media.mediaTypeId
+    FROM media
+    INNER JOIN mediaClipEmbeddings e
+      ON e.mediaId = media.id AND e.model = :model
+  `
+  if (reason === 'viewed') {
+    sql += `
+      WHERE media.viewedAt IS NOT NULL AND media.viewedAt != ''
+      ORDER BY media.viewedAt DESC
+    `
+  } else if (reason === 'favorite') {
+    sql += `
+      WHERE media.favorite = 1
+      ORDER BY media.viewedAt DESC, media.id DESC
+    `
+  } else {
+    sql += `
+      ORDER BY media.viewedAt DESC, media.id DESC
+    `
+  }
+  sql += ` LIMIT :limit`
+
+  const rows = queryAll(db, sql, {
+    model: CLIP_EMBEDDING_INDEX_KEY,
+    limit: SEED_CANDIDATE_LIMIT,
+  })
+  return rows.map((row) => mapSeedRow(row, reason))
+}
+
+export async function getHomeSimilar(
+  db: ApiDb,
+  options: {limit?: number; random?: () => number} = {},
+): Promise<HomeSimilarResult> {
+  const limit = Math.min(Math.max(Number(options.limit) || 12, 1), 24)
+  const indexed = queryGet<{count?: number}>(db, `
+    SELECT COUNT(*) AS count
+    FROM mediaClipEmbeddings
+    WHERE model = :model
+  `, {model: CLIP_EMBEDDING_INDEX_KEY})
+  if (!Number(indexed?.count)) {
+    return {seed: null, items: []}
+  }
+
+  const pools: HomeSimilarSeedReason[] = ['viewed', 'favorite', 'any']
+  let seed: HomeSimilarSeed | null = null
+  for (const reason of pools) {
+    const candidates = loadSeedCandidates(db, reason)
+    const seedId = chooseHomeSimilarSeedId(
+      candidates.map((entry) => entry.id),
+      options.random,
+    )
+    if (seedId == null) continue
+    seed = candidates.find((entry) => entry.id === seedId) || mapSeedRow({id: seedId}, reason)
+    break
+  }
+
+  if (!seed) return {seed: null, items: []}
+
+  const similar = await findSimilarByClip(db, seed.id, {limit: limit + 1})
+  if (!similar.hasEmbedding) {
+    return {seed: null, items: []}
+  }
+
+  const neighborIds = (similar.ids || [])
+    .map(Number)
+    .filter((id) => Number.isFinite(id) && id > 0 && id !== seed!.id)
+    .slice(0, limit)
+
+  if (!neighborIds.length) {
+    return {seed, items: []}
+  }
+
+  const rows = await loadMediaBasicsByIds(db, neighborIds)
+  const byId = new Map(rows.map((row: AnyRecord) => [Number(row.id), row]))
+  const items = neighborIds
+    .map((id) => {
+      const row = byId.get(id)
+      if (!row) return null
+      return {
+        ...row,
+        tags: [],
+        values: [],
+        key: String(row.id),
+      }
+    })
+    .filter(Boolean) as AnyRecord[]
+
+  return {seed, items}
+}

--- a/shared/api/routes.ts
+++ b/shared/api/routes.ts
@@ -93,6 +93,7 @@ export const API_ROUTES = {
   homeMarkers: '/api/home/markers',
   homeHealth: '/api/home/health',
   homeHealthLite: '/api/home/health-lite',
+  homeSimilar: '/api/home/similar',
   globalSearchMedia: '/api/home/search/media',
   globalSearchTags: '/api/home/search/tags',
   globalSearch: '/api/home/search',

--- a/shared/schemas/home.ts
+++ b/shared/schemas/home.ts
@@ -190,6 +190,20 @@ export const HomeMediaResponseSchema = z.object({
   items: z.array(MediaItemSchema).optional(),
 }).passthrough()
 
+export const HomeSimilarSeedSchema = z.object({
+  id: z.number(),
+  name: z.string().nullable().optional(),
+  basename: z.string().nullable().optional(),
+  path: z.string().nullable().optional(),
+  mediaTypeId: z.number().nullable().optional(),
+  reason: z.enum(['viewed', 'favorite', 'any']).optional(),
+}).passthrough()
+
+export const HomeSimilarResponseSchema = z.object({
+  seed: HomeSimilarSeedSchema.nullable(),
+  items: z.array(MediaItemSchema),
+}).passthrough()
+
 export const MissingMediaStatusSchema = z.object({
   total: z.number().optional(),
   missing: z.number().optional(),
@@ -276,3 +290,4 @@ export type HealthQueueItem = NonNullable<ParsedHomeHealth['queue']>[number]
 export type HealthQueueItemId = z.infer<typeof HealthQueueItemIdSchema>
 export type ParsedHomeMarkers = z.infer<typeof HomeMarkersSchema>
 export type ParsedHomeMediaResponse = z.infer<typeof HomeMediaResponseSchema>
+export type ParsedHomeSimilarResponse = z.infer<typeof HomeSimilarResponseSchema>

--- a/shared/schemas/index.ts
+++ b/shared/schemas/index.ts
@@ -21,6 +21,7 @@ import {
   HomeHealthLiteSchema,
   HomeMarkersSchema,
   HomeMediaResponseSchema,
+  HomeSimilarResponseSchema,
   HomeMediaStatsSchema,
   HomeTagCountSchema,
   MediaThumbsResponseSchema,
@@ -202,6 +203,10 @@ export function parseHomeMarkers(data: unknown) {
 
 export function parseHomeMediaResponse(data: unknown) {
   return HomeMediaResponseSchema.parse(data)
+}
+
+export function parseHomeSimilarResponse(data: unknown) {
+  return HomeSimilarResponseSchema.parse(data)
 }
 
 export function parseMissingMediaStatus(data: unknown) {
@@ -481,6 +486,7 @@ export {
   HomeHealthLiteSchema,
   HomeMarkersSchema,
   HomeMediaResponseSchema,
+  HomeSimilarResponseSchema,
   HomeMediaStatsSchema,
   HomeTagCountSchema,
   MediaThumbsResponseSchema,

--- a/src/components/widgets/HomeWidgetRenderer.vue
+++ b/src/components/widgets/HomeWidgetRenderer.vue
@@ -45,6 +45,13 @@
   </WidgetLazyMount>
 
   <WidgetLazyMount
+    v-else-if="widgetId === 'similar'"
+    min-height="220px"
+  >
+    <WidgetHomeSimilar :limit="limits?.similar ?? 12"/>
+  </WidgetLazyMount>
+
+  <WidgetLazyMount
     v-else-if="widgetId === 'favorites'"
     min-height="220px"
     @activate="ensureHomeMediaLoaded"
@@ -114,6 +121,7 @@ import type {MediaItem} from '@/types/stores'
 const WidgetTopTags = defineAsyncComponent(() => import('@/components/widgets/WidgetTopTags.vue'))
 const WidgetRandomMarkers = defineAsyncComponent(() => import('@/components/widgets/WidgetRandomMarkers.vue'))
 const WidgetHealthAlerts = defineAsyncComponent(() => import('@/components/widgets/WidgetHealthAlerts.vue'))
+const WidgetHomeSimilar = defineAsyncComponent(() => import('@/components/widgets/WidgetHomeSimilar.vue'))
 
 const props = defineProps<{
   widgetId: string

--- a/src/components/widgets/HomeWidgetsEditor.vue
+++ b/src/components/widgets/HomeWidgetsEditor.vue
@@ -93,6 +93,10 @@ const widgetMeta = computed(() => ({
     title: t('home.widgets.continue_watching'),
     icon: 'mdi-history',
   },
+  similar: {
+    title: t('home.widgets.similar'),
+    icon: 'mdi-creation-outline',
+  },
   favorites: {
     title: t('home.widgets.favorites'),
     icon: 'mdi-heart',

--- a/src/components/widgets/WidgetHomeSimilar.vue
+++ b/src/components/widgets/WidgetHomeSimilar.vue
@@ -1,0 +1,123 @@
+<template>
+  <section
+    v-if="loading || items.length"
+    class="widget-home-similar mb-6"
+  >
+    <WidgetMediaRow
+      :title="title"
+      icon="mdi-creation-outline"
+      :items="items"
+      :loading="loading"
+      variant="views"
+      @open="onOpen"
+      @view-all="onViewAll"
+    />
+  </section>
+</template>
+
+<script setup lang="ts">
+import {computed, onMounted, ref, watch} from 'vue'
+import {useI18n} from 'vue-i18n'
+import {typedApi} from '@/services/typedApi'
+import {useAppStore} from '@/stores/app'
+import {useItemsStore} from '@/stores/items'
+import {useOpenMediaList} from '@/utils/openMediaList'
+import {loadHomeMediaThumbs} from '@/utils/homeMediaThumbs'
+import {resolveOpenMediaKind} from '@/utils/openMediaKind'
+import {openTextMedia} from '@/utils/openTextMedia'
+import {findMediaTypeById} from '@/utils/mediaType'
+import WidgetMediaRow from '@/components/widgets/WidgetMediaRow.vue'
+import type {MediaItem} from '@/types/stores'
+import type {ParsedHomeSimilarResponse} from '@shared/schemas/home'
+
+const props = withDefaults(defineProps<{
+  limit?: number
+}>(), {
+  limit: 12,
+})
+
+const {t} = useI18n()
+const appStore = useAppStore()
+const itemsStore = useItemsStore()
+const {openMediaList} = useOpenMediaList()
+
+const loading = ref(false)
+const payload = ref<ParsedHomeSimilarResponse>({seed: null, items: []})
+const items = ref<MediaItem[]>([])
+
+const seedLabel = computed(() => {
+  const seed = payload.value.seed
+  if (!seed) return ''
+  return String(seed.name || seed.basename || '').trim()
+})
+
+const title = computed(() => {
+  if (seedLabel.value) {
+    return t('home.widgets.similar_to', {name: seedLabel.value})
+  }
+  return t('home.widgets.similar')
+})
+
+async function loadSimilar() {
+  loading.value = true
+  try {
+    const res = await typedApi.getHomeSimilar({limit: props.limit})
+    payload.value = res.data
+    const nextItems = (res.data.items || []) as MediaItem[]
+    await loadHomeMediaThumbs(nextItems, appStore.mediaTypes, appStore.mediaPath)
+    items.value = nextItems
+  } catch (error) {
+    console.error(error)
+    payload.value = {seed: null, items: []}
+    items.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+async function onOpen(item: MediaItem) {
+  const mediaType = findMediaTypeById(appStore.mediaTypes, item.mediaTypeId)
+  const kind = resolveOpenMediaKind(mediaType, {path: item.path})
+
+  if (kind === 'play-av') {
+    await itemsStore.playVideo({
+      video: item,
+      videos: items.value.length ? items.value : [item],
+    })
+    return
+  }
+  if (kind === 'view-image') {
+    itemsStore.viewImage({image: item})
+    return
+  }
+  if (kind === 'preview-text' || kind === 'open-path') {
+    openTextMedia(item)
+    return
+  }
+  await openMediaList({mediaTypeId: item.mediaTypeId})
+}
+
+function onViewAll() {
+  const ids = items.value.map((item) => Number(item.id)).filter((id) => id > 0)
+  if (!ids.length) return
+  const seed = payload.value.seed
+  void openMediaList({
+    mediaTypeId: seed?.mediaTypeId != null ? Number(seed.mediaTypeId) : undefined,
+    ids,
+    scope: {
+      kind: 'clipSimilar',
+      label: seedLabel.value
+        ? t('home.widgets.similar_to', {name: seedLabel.value})
+        : t('items.more_like_this_scope'),
+    },
+  })
+}
+
+watch(() => props.limit, () => {
+  void loadSimilar()
+})
+
+onMounted(() => {
+  void loadSimilar()
+})
+</script>

--- a/src/i18n/cn.ts
+++ b/src/i18n/cn.ts
@@ -732,6 +732,8 @@ const cn = {
       search: '搜索',
       drop_hint: '将文件或文件夹拖放到此处以添加',
       continue_watching: '继续观看',
+      similar: '相似',
+      similar_to: '与 {name} 相似',
       favorites: '收藏',
       top_views: '观看最多',
       view_all: '查看全部',

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -732,6 +732,8 @@ const de = {
       search: 'Suchen',
       drop_hint: 'Ziehen Sie Dateien oder Ordner hierher, um sie hinzuzufügen',
       continue_watching: 'Schauen Sie weiter',
+      similar: 'Ähnlich',
+      similar_to: 'Ähnlich wie {name}',
       favorites: 'Favoriten',
       top_views: 'Oben nach Ansichten',
       view_all: 'Alle anzeigen',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -732,6 +732,8 @@ const en = {
       search: 'Search',
       drop_hint: 'Drag files or folders here to add them',
       continue_watching: 'Continue watching',
+      similar: 'Similar',
+      similar_to: 'Similar to {name}',
       favorites: 'Favorites',
       top_views: 'Top by views',
       view_all: 'View all',

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -732,6 +732,8 @@ const es = {
       search: 'Buscar',
       drop_hint: 'Arrastra archivos o carpetas aquí para añadirlos',
       continue_watching: 'Continuar viendo',
+      similar: 'Similares',
+      similar_to: 'Similar a {name}',
       favorites: 'Favoritos',
       top_views: 'Más vistos',
       view_all: 'Ver todo',

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -732,6 +732,8 @@ const fr = {
       search: 'Rechercher',
       drop_hint: 'Faites glisser des fichiers ou des dossiers ici pour les ajouter',
       continue_watching: 'Continuer à regarder',
+      similar: 'Similaires',
+      similar_to: 'Similaire à {name}',
       favorites: 'Favoris',
       top_views: 'Top par vues',
       view_all: 'Voir tout',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -732,6 +732,8 @@ const ja = {
       search: '検索',
       drop_hint: 'ファイルまたはフォルダーをここにドラッグして追加します',
       continue_watching: '視聴を続ける',
+      similar: '類似',
+      similar_to: '{name} に似た作品',
       favorites: 'お気に入り',
       top_views: 'ビュー別上位',
       view_all: 'すべて見る',

--- a/src/i18n/pt.ts
+++ b/src/i18n/pt.ts
@@ -732,6 +732,8 @@ const pt = {
       search: 'Pesquisar',
       drop_hint: 'Arraste arquivos ou pastas aqui para adicioná-los',
       continue_watching: 'Continuar assistindo',
+      similar: 'Semelhantes',
+      similar_to: 'Semelhante a {name}',
       favorites: 'Favoritos',
       top_views: 'Principais por visualizações',
       view_all: 'Ver tudo',

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -732,6 +732,8 @@ const ru = {
       search: 'Поиск',
       drop_hint: 'Перетащите файлы или папки сюда для добавления',
       continue_watching: 'Продолжить просмотр',
+      similar: 'Похожее',
+      similar_to: 'Похоже на {name}',
       favorites: 'Избранное',
       top_views: 'Топ по просмотрам',
       view_all: 'Все',

--- a/src/services/typedApi/home.ts
+++ b/src/services/typedApi/home.ts
@@ -12,6 +12,7 @@ import {
   parseHomeHealthLite,
   parseHomeMarkers,
   parseHomeMediaResponse,
+  parseHomeSimilarResponse,
   parseHomeMediaStats,
   parseHomeTagCount,
   parseMediaThumbsResponse,
@@ -25,6 +26,13 @@ export const homeApi = {
     return apiClient.get<HomeMediaResponse>(API_ROUTES.homeMedia, { params }).then((res) => ({
       ...res,
       data: validated(parseHomeMediaResponse, res.data),
+    }))
+  },
+
+  getHomeSimilar(params?: {limit?: number}) {
+    return apiClient.get(API_ROUTES.homeSimilar, {params}).then((res) => ({
+      ...res,
+      data: validated(parseHomeSimilarResponse, res.data),
     }))
   },
 

--- a/src/utils/homeWidgets.ts
+++ b/src/utils/homeWidgets.ts
@@ -4,6 +4,7 @@ export const HOME_WIDGET_IDS = [
   'chartStats',
   'quickActions',
   'continue',
+  'similar',
   'favorites',
   'topViews',
   'markers',
@@ -15,6 +16,7 @@ export type HomeWidgetId = typeof HOME_WIDGET_IDS[number]
 
 export const HOME_WIDGETS_WITH_LIMIT = [
   'continue',
+  'similar',
   'favorites',
   'topViews',
   'markers',
@@ -35,6 +37,7 @@ export const DEFAULT_HOME_WIDGETS_CONFIG: HomeWidgetsConfig = {
     'chartStats',
     'quickActions',
     'continue',
+    'similar',
     'favorites',
     'stats',
     'extendedStats',
@@ -49,6 +52,7 @@ export const DEFAULT_HOME_WIDGETS_CONFIG: HomeWidgetsConfig = {
     chartStats: true,
     quickActions: true,
     continue: true,
+    similar: true,
     favorites: true,
     topViews: false,
     markers: false,
@@ -57,6 +61,7 @@ export const DEFAULT_HOME_WIDGETS_CONFIG: HomeWidgetsConfig = {
   },
   limits: {
     continue: 12,
+    similar: 12,
     favorites: 12,
     topViews: 12,
     markers: 8,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a Home **Similar** row next to Continue — CLIP neighbors for a recently viewed (else favorite / any indexed) seed.

## Behavior
- New `GET /api/home/similar?limit=`
- Widget `similar` on by default, right after Continue
- Title: **Similar to {seed}**
- View all opens a scoped media list (`clipSimilar`)
- Hidden when there is no CLIP index / no neighbors

## Product
Canvas: sell discovery on Home; keep health/setup in Settings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bed2fd9-1296-415a-8820-83bf1820c03e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bed2fd9-1296-415a-8820-83bf1820c03e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

